### PR TITLE
Deduplicate (url, commits) pairs before checking LeanGitRepo in cache to speed up trace_repos.py

### DIFF
--- a/scripts/trace_repos.py
+++ b/scripts/trace_repos.py
@@ -11,14 +11,17 @@ def main() -> None:
     args = parser.parse_args()
     logger.info(args)
 
-    repos = set()
-
+    url_commits = set()
     for path in glob(f"{args.data_path}/*/*/*.json"):
         data = json.load(open(path))
         for ex in data:
-            repo = LeanGitRepo(ex["url"], ex["commit"])
-            if not is_available_in_cache(repo):
-                repos.add(repo)
+            url_commits.add((ex["url"], ex["commit"]))
+
+    repos = set()
+    for url, commit in url_commits:
+        repo = LeanGitRepo(url, commit)
+        if not is_available_in_cache(repo):
+            repos.add(repo)
 
     logger.info(f"Repos to trace: {repos}")
 


### PR DESCRIPTION
Following README.md for `python scripts/download_data.py` followed by `python scripts/trace_repos.py` trace_repos takes significant time to find repos to trace from 285690 entries in jsons with 42.73it/s with no visual progress report. (~6330 seconds)

Deduplicating (URL, commits) before creating repo object and checking in cache filesystem speeds it up to ~10s