### PR TITLE
When evaluation done, add case which all theorem is discarded. Modify num_gpus in ray.init

### DIFF
--- a/prover/evaluate.py
+++ b/prover/evaluate.py
@@ -167,7 +167,7 @@ def main() -> None:
         f"Evaluation done! {num_proved} theorems proved, {num_failed} theorems failed, {num_discarded} non-theorems discarded"
     )
     if num_proved + num_failed == 0 :
-        logger.info(f"Pass@1 : 0")
+        logger.info("Pass@1 : NaN")
     else :
         logger.info(f"Pass@1: {num_proved / (num_proved + num_failed)}")
 

--- a/prover/evaluate.py
+++ b/prover/evaluate.py
@@ -166,7 +166,10 @@ def main() -> None:
     logger.info(
         f"Evaluation done! {num_proved} theorems proved, {num_failed} theorems failed, {num_discarded} non-theorems discarded"
     )
-    logger.info(f"Pass@1: {num_proved / (num_proved + num_failed)}")
+    if num_proved + num_failed == 0 :
+        logger.info(f"Pass@1 : 0")
+    else :
+        logger.info(f"Pass@1: {num_proved / (num_proved + num_failed)}")
 
     # Save the results.
     if args.exp_id is not None:

--- a/prover/evaluate.py
+++ b/prover/evaluate.py
@@ -87,10 +87,7 @@ def main() -> None:
         help="Path to the data extracted by LeanDojo (e.g., data/leandojo_benchmark/random).",
     )
     parser.add_argument(
-        "--split",
-        type=str,
-        choices=["train", "val", "test"],
-        default="val",
+        "--split", type=str, choices=["train", "val", "test"], default="val",
     )
     # `file_path`, `full_name`, `name_filter`, and `num_theorems` can be used to filter theorems.
     parser.add_argument("--file-path", type=str)
@@ -166,9 +163,9 @@ def main() -> None:
     logger.info(
         f"Evaluation done! {num_proved} theorems proved, {num_failed} theorems failed, {num_discarded} non-theorems discarded"
     )
-    if num_proved + num_failed == 0 :
+    if num_proved + num_failed == 0:
         logger.info("Pass@1 : NaN")
-    else :
+    else:
         logger.info(f"Pass@1: {num_proved / (num_proved + num_failed)}")
 
     # Save the results.

--- a/prover/proof_search.py
+++ b/prover/proof_search.py
@@ -383,7 +383,8 @@ class DistributedProver:
 
         if with_gpus:
             logger.info(f"Launching {num_cpus} GPU workers.")
-            ray.init(num_cpus=num_cpus, num_gpus=num_cpus)
+            num_gpus = torch.cuda.device_count()
+            ray.init(num_cpus=num_cpus, num_gpus=num_gpus)
             provers = [
                 GpuProver.remote(
                     ckpt_path,

--- a/prover/proof_search.py
+++ b/prover/proof_search.py
@@ -383,8 +383,7 @@ class DistributedProver:
 
         if with_gpus:
             logger.info(f"Launching {num_cpus} GPU workers.")
-            num_gpus = torch.cuda.device_count()
-            ray.init(num_cpus=num_cpus, num_gpus=num_gpus)
+            ray.init(num_cpus=num_cpus, num_gpus=num_cpus)
             provers = [
                 GpuProver.remote(
                     ckpt_path,


### PR DESCRIPTION
Hi, I experiment your code,
I think the some of code would be good if it is changed.

1. After evaluation is done, in my experiment, all theorem are discarded, so I meet `ZeroDivisionError`.
Hence, by using `if`, adding the case of all theorem are discarded can avoid the `ZeroDivisionError`.

2. When evaluating with gpus and cpus more than 2 respectively,
`ray.init` takes the argument `num_gpus` as `num_cpus`.
It cause the error in case of num gpus and num cpus are not equal.
I think it is typo, because it is easy to confuse num_cpus and num_gpus.
So, add `torch.cuda.device_count()` to find num_gpus instead of getting num_gpus as arguments.

Thank you for spending your time,
I hope to merge my modification soon. :)
