### PR TITLE
url, hashcode in scripts/download_data.py

### DIFF
--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -6,7 +6,7 @@ from loguru import logger
 
 
 LEANDOJO_BENCHMARK_URL = (
-    "https://zenodo.org/records/10044546/leandojo_benchmark_v3.tar.gz"
+    "https://zenodo.org/records/10114157/files/leandojo_benchmark_v5.tar.gz?download=1"
 )
 LEANDOJO_BENCHMARK_4_URL = (
     "https://zenodo.org/records/10044516/files/leandojo_benchmark_4_v3.tar.gz"

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -9,11 +9,11 @@ LEANDOJO_BENCHMARK_URL = (
     "https://zenodo.org/records/10114157/files/leandojo_benchmark_v5.tar.gz"
 )
 LEANDOJO_BENCHMARK_4_URL = (
-    "https://zenodo.org/records/10044516/files/leandojo_benchmark_4_v3.tar.gz"
+    "https://zenodo.org/records/10114185/files/leandojo_benchmark_4_v5.tar.gz"
 )
 DOWNLOADS = {
     LEANDOJO_BENCHMARK_URL: "4b256200618d4668b12a9cfe8c4df4d3",
-    LEANDOJO_BENCHMARK_4_URL: "908c56335f7c079721385e6d9c04cdf8",
+    LEANDOJO_BENCHMARK_4_URL: "5c1bb0ce1fd1572e8c3d0c3a642e356f",
 }
 
 

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -6,13 +6,13 @@ from loguru import logger
 
 
 LEANDOJO_BENCHMARK_URL = (
-    "https://zenodo.org/records/10114157/files/leandojo_benchmark_v5.tar.gz?download=1"
+    "https://zenodo.org/records/10114157/files/leandojo_benchmark_v5.tar.gz"
 )
 LEANDOJO_BENCHMARK_4_URL = (
     "https://zenodo.org/records/10044516/files/leandojo_benchmark_4_v3.tar.gz"
 )
 DOWNLOADS = {
-    LEANDOJO_BENCHMARK_URL: "a4fed5dec29bc8ac25f4a5a48edfa265",
+    LEANDOJO_BENCHMARK_URL: "4b256200618d4668b12a9cfe8c4df4d3",
     LEANDOJO_BENCHMARK_4_URL: "908c56335f7c079721385e6d9c04cdf8",
 }
 


### PR DESCRIPTION
Hi, I found an error when running scripts/download_data.py.

Since the benchmark version was updated from v3 to v5,
the url and the hashcode are changed, but the code has not changed.
So, I change the latest urls and hashcodes in both Lean version 3 and 4.

After making the changes, I run scripts/download_data.py and there are no errors.

Please check them!
Thanks! :)
