### PR TITLE
Fix Missing `TimeoutError` by Replacing with `DojoTacticTimeoutError`

### DIFF
--- a/prover/proof_search.py
+++ b/prover/proof_search.py
@@ -14,7 +14,6 @@ from lean_dojo import (
     LeanGitRepo,
     TacticState,
     LeanError,
-    TimeoutError,
     ProofFinished,
     ProofGivenUp,
     DojoInitError,
@@ -256,7 +255,7 @@ class BestFirstSearchProver:
                 result_node = ProofFinishedNode(response)
             elif type(response) in (
                 LeanError,
-                TimeoutError,
+                DojoTacticTimeoutError,
                 ProofGivenUp,
             ):
                 result_node = ErrorNode(response)
@@ -295,7 +294,7 @@ class BestFirstSearchProver:
                 assert self.root.status == Status.PROVED
             elif type(response) in (
                 LeanError,
-                TimeoutError,
+                DojoTacticTimeoutError,
                 ProofGivenUp,
             ):
                 assert isinstance(node, ErrorNode)

--- a/prover/search_tree.py
+++ b/prover/search_tree.py
@@ -6,7 +6,7 @@ from enum import Enum
 from lean_dojo import (
     TacticState,
     LeanError,
-    TimeoutError,
+    DojoTacticTimeoutError,
     ProofGivenUp,
     ProofFinished,
 )
@@ -52,7 +52,7 @@ class ProofFinishedNode(Node):
 
 @dataclass
 class ErrorNode(Node):
-    inner: Union[LeanError, TimeoutError, ProofGivenUp]
+    inner: Union[LeanError, DojoTacticTimeoutError, ProofGivenUp]
     status = Status.FAILED
     distance_to_proof = math.inf
     is_terminal = True


### PR DESCRIPTION
The old `TimeoutError` was removed from the LeanDojo repository, but the current Reprover implementation still references it, leading to inconsistencies. In this PR, I’ve addressed this issue by replacing all instances of `TimeoutError` with `DojoTacticTimeoutError `.